### PR TITLE
Adds MCP Server Docker capability

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,27 @@
+name: publish
+
+on: [push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+    publish-docker-image:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                registry: ghcr.io
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Convert Repository name to lower case
+              id: lowercase
+              run: echo "REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+            - name: Build the MCP Docker Image
+              run: |
+                docker build . --tag ghcr.io/${{ env.REPO }}
+                docker run ghcr.io/${{ env.REPO }}:latest
+                docker push ghcr.io/${{ env.REPO }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/astral-sh/uv:latest AS uv
 
+# Copy the uv binary to a known location
+COPY --from=uv /uv /bin/uv
+
 WORKDIR /app
 
 COPY uv.lock /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/astral-sh/uv:latest AS uvbase
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm AS uv
 
 # Copy the uv binary to a known location
-COPY --from=uvbase /uv /bin/uv
+COPY --from=uv /uv /bin/uv
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/astral-sh/uv:latest AS uv
+FROM ghcr.io/astral-sh/uv:latest AS uvbase
 
 # Copy the uv binary to a known location
-COPY --from=uv /uv /bin/uv
+COPY --from=uvbase /uv /bin/uv
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ FROM python:3.10-slim-bookworm
 
 WORKDIR /app
 
+# Install system dependencies for OpenCV
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=uv /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
+WORKDIR /app
+
+COPY uv.lock /app/
+COPY pyproject.toml /app/
+COPY README.md /app/
+COPY .python-version /app/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
+    --mount=type=bind,source=.python-version,target=.python-version \
+    uv sync --frozen --no-dev --no-editable
+
+ADD ./src/mcp_local_rag /app/mcp_local_rag
+
+FROM python:3.10-slim-bookworm
+
+WORKDIR /app
+
+COPY --from=uv /app/.venv /app/.venv
+COPY --from=uv /app /app/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH=/app
+
+ENTRYPOINT [ "mcp-local-rag" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ghcr.io/astral-sh/uv:python3.10-bookworm AS uv
 
-# Copy the uv binary to a known location
-COPY --from=uv /uv /bin/uv
-
 WORKDIR /app
 
 COPY uv.lock /app/
@@ -23,10 +20,11 @@ FROM python:3.10-slim-bookworm
 
 WORKDIR /app
 
-COPY --from=uv /app/.venv /app/.venv
-COPY --from=uv /app /app/
+# COPY --from=uv /app/.venv /app/.venv
+# ENV PATH="/app/.venv/bin:$PATH"
 
-ENV PATH="/app/.venv/bin:$PATH"
+COPY --from=uv /app /app/
+ENV UV_SYSTEM_PYTHON=1
 ENV PYTHONPATH=/app
 
-ENTRYPOINT [ "mcp-local-rag" ]
+ENTRYPOINT ["mcp-local-rag"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,10 @@ FROM python:3.10-slim-bookworm
 
 WORKDIR /app
 
-# COPY --from=uv /app/.venv /app/.venv
-# ENV PATH="/app/.venv/bin:$PATH"
+COPY --from=uv /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --from=uv /app /app/
-ENV UV_SYSTEM_PYTHON=1
 ENV PYTHONPATH=/app
 
 ENTRYPOINT ["mcp-local-rag"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,10 @@ FROM python:3.10-slim-bookworm
 
 WORKDIR /app
 
-# Install system dependencies for OpenCV
+# Install system dependencies for OpenCV + MediaPipe
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=uv /app/.venv /app/.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
     --mount=type=bind,source=.python-version,target=.python-version \
-    uv sync --frozen --no-dev --no-editable
+    ["uv", "sync", "--frozen", "--no-dev", "--no-editable"]
 
 ADD ./src/mcp_local_rag /app/mcp_local_rag
 


### PR DESCRIPTION
Adds capability of adding a MCP Server via Docker.

Builds and publishes the container image to GitHub Container Registry, making it up-to-date from every push.

Tested it locally via Claude Desktop, and after some trial-and-error, it works successfully as shown in the screenshot below:

![image](https://github.com/user-attachments/assets/9986fb73-a475-4970-ac93-1b95d09f6735)

Currently the PR will be kept to draft, will convert it to 'Ready' once the README file has been updated with the setup via Docker.
