### PR TITLE
Fixes permission when publishing Docker image to GCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -8,6 +8,11 @@ concurrency:
 
 jobs:
   publish-docker-image:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Added the `permissions` tag for the job.

Reference: https://github.com/orgs/community/discussions/57724