### PR TITLE
Use `python3.10-bookworm-slim` base image for smaller Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.10-bookworm AS uv
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim AS uv
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR updates the base image in the `Dockerfile` from `python3.10-bookworm` to `python3.10-bookworm-slim`.

The `-slim` variant is a lighter version of the original image, which helps reduce the final Docker image size, leading to faster builds and deployments. No functional changes are introduced with this update.