### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,8 @@ Have ideas or want to improve this project? Issues and pull requests are welcome
 
 # License
 This project is licensed under the MIT License.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nkapila6-mcp-local-rag).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/nkapila6-mcp-local-rag)