### PR TITLE
Update Linguist rules for Skill markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,8 @@ Dockerfile linguist-detectable=false
 *.mermaid linguist-detectable=false
 *.sh linguist-detectable=false
 .envrc linguist-detectable=false
+
+README.md linguist-documentation
+skills/README.md linguist-documentation
+skills/local-rag-search/README.md linguist-documentation
+skills/local-rag-search/SKILL.md linguist-detectable


### PR DESCRIPTION
This PR updates `.gitattributes` to improve how GitHub Linguist
classifies markdown files related to Skills.

* Marks root and Skills README files as documentation
* Ensures `SKILL.md` is treated as detectable content
* Improves accuracy of repository language statistics

No functional code changes; metadata-only update.